### PR TITLE
Prisili uporabo slike s knjižnico Quandl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Nastavitvena datoteka za Binder
-FROM jaanos/appr:base-2020
+FROM jaanos/appr:base-2021-02-28
 
 ENV PROJECT_DIR ${HOME}/APPR-2020-21
 ENV PROJECT_FILE ${PROJECT_DIR}/APPR-2020-21.Rproj


### PR DESCRIPTION
Očitno Binder pri zadnjem commitu še ni zagrabil posodobljene slike, tako da je tukaj popravek, ki prisili njeno uporabo. [Tukaj](https://mybinder.org/v2/gh/jaanos/APPR-2020-21/Ian-Spiller?urlpath=shiny/APPR-2020-21/projekt.Rmd) lahko vidiš, kako izgleda poganjanje na Binderju s tem popravkom.

Da sprejmeš ta pull request, ga torej odpri na GitHubu in klikni na **Merge pull request**, nato pa pri sebi naredi *pull*, da pridobiš spremembe.